### PR TITLE
Feature/admin endpoints

### DIFF
--- a/apps/convex-backend/convex/_generated/api.d.ts
+++ b/apps/convex-backend/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as auth from "../auth.js";
 import type * as helpRequests from "../helpRequests.js";
 import type * as http from "../http.js";
+import type * as lib_currentUser from "../lib/currentUser.js";
 import type * as lib_siteEnv from "../lib/siteEnv.js";
 import type * as lib_verifyResendWebhook from "../lib/verifyResendWebhook.js";
 import type * as notifications from "../notifications.js";
@@ -29,6 +30,7 @@ declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   helpRequests: typeof helpRequests;
   http: typeof http;
+  "lib/currentUser": typeof lib_currentUser;
   "lib/siteEnv": typeof lib_siteEnv;
   "lib/verifyResendWebhook": typeof lib_verifyResendWebhook;
   notifications: typeof notifications;

--- a/apps/convex-backend/convex/helpRequests.ts
+++ b/apps/convex-backend/convex/helpRequests.ts
@@ -60,6 +60,40 @@ async function createNotification(ctx: MutationCtx, args: {
 	});
 }
 
+/**
+ * Hard-delete a request and everything that references it. Isolated behind
+ * this helper so the delete strategy can change without touching callers.
+ *
+ * To switch to a soft delete later: add `deletedAt: v.optional(v.number())`
+ * to helpRequests in schema.ts, filter `deletedAt` rows out of the user/
+ * volunteer queries (listMine, listPendingFromOthers, getAsHelper,
+ * listAllForAdmin, getOfferHelperPreview), add a restore mutation, and change
+ * this helper to patch `deletedAt` instead of deleting. adminDeleteRequest's
+ * public signature stays the same across that change.
+ */
+async function purgeRequest(ctx: MutationCtx, requestId: Id<"helpRequests">) {
+	// Messages are indexed by request, so this is a targeted delete.
+	const messages = await ctx.db
+		.query("requestMessages")
+		.withIndex("by_request", q => q.eq("requestId", requestId))
+		.collect();
+	for (const message of messages) {
+		await ctx.db.delete("requestMessages", message._id);
+	}
+
+	// notifications has no requestId index, so we scan and filter. Cost is
+	// O(total notifications); acceptable at current scale. If notification
+	// volume grows, add a by_request_id index and query it instead.
+	const notifications = await ctx.db.query("notifications").collect();
+	for (const notification of notifications) {
+		if (notification.requestId === requestId) {
+			await ctx.db.delete("notifications", notification._id);
+		}
+	}
+
+	await ctx.db.delete("helpRequests", requestId);
+}
+
 function volunteerLabelForNotification(helper: {
 	firstName?: string;
 	name?: string;
@@ -533,6 +567,25 @@ export const adminUpdateRequest = mutation({
 			patch.category = category;
 		}
 		await ctx.db.patch("helpRequests", requestId, patch);
+	},
+});
+
+export const adminDeleteRequest = mutation({
+	args: { requestId: v.id("helpRequests") },
+	// Hard delete chosen for the initial version: the row and its dependents
+	// (messages, notifications) are removed via purgeRequest. This can be
+	// swapped for a soft delete later without changing this signature — see
+	// the note on purgeRequest.
+	handler: async (ctx, { requestId }) => {
+		const identity = await requireIdentity(ctx);
+		if (!isAdminIdentity(identity)) {
+			throw new Error("Forbidden");
+		}
+		const doc = await ctx.db.get("helpRequests", requestId);
+		if (!doc) {
+			throw new Error("Request not found.");
+		}
+		await purgeRequest(ctx, requestId);
 	},
 });
 

--- a/apps/convex-backend/convex/helpRequests.ts
+++ b/apps/convex-backend/convex/helpRequests.ts
@@ -497,6 +497,45 @@ export const assignVolunteer = mutation({
 	},
 });
 
+export const adminUpdateRequest = mutation({
+	args: {
+		requestId: v.id("helpRequests"),
+		title: v.optional(v.string()),
+		summary: v.optional(v.string()),
+		details: v.optional(v.string()),
+		category: v.optional(requestCategory),
+	},
+	handler: async (ctx, { requestId, title, summary, details, category }) => {
+		const identity = await requireIdentity(ctx);
+		if (!isAdminIdentity(identity)) {
+			throw new Error("Forbidden");
+		}
+		const doc = await ctx.db.get("helpRequests", requestId);
+		if (!doc) {
+			throw new Error("Request not found.");
+		}
+		const patch: {
+			title?: string;
+			summary?: string;
+			details?: string;
+			category?: Doc<"helpRequests">["category"];
+		} = {};
+		if (title !== undefined) {
+			patch.title = title;
+		}
+		if (summary !== undefined) {
+			patch.summary = summary;
+		}
+		if (details !== undefined) {
+			patch.details = details;
+		}
+		if (category !== undefined) {
+			patch.category = category;
+		}
+		await ctx.db.patch("helpRequests", requestId, patch);
+	},
+});
+
 export const create = mutation({
 	args: {
 		category: requestCategory,

--- a/apps/lomoweb/app/app/admin/admin-dashboard.tsx
+++ b/apps/lomoweb/app/app/admin/admin-dashboard.tsx
@@ -10,6 +10,7 @@ import { Text } from "@repo/ui/text";
 import { useMutation, useQuery } from "convex/react";
 import { useMemo, useState } from "react";
 import { HELP_REQUEST_STATUS_LABEL, statusBadgeColor } from "@/lib/help-request-status";
+import { AdminRequestDetail } from "./admin-request-detail";
 
 export function AdminDashboard() {
 	const isAdmin = useQuery(api.helpRequests.isAdmin, {});
@@ -18,6 +19,14 @@ export function AdminDashboard() {
 	const assignVolunteer = useMutation(api.helpRequests.assignVolunteer);
 	const [assigningId, setAssigningId] = useState<string | null>(null);
 	const [selectedByRequest, setSelectedByRequest] = useState<Record<string, string>>({});
+	const [detailId, setDetailId] = useState<Id<"helpRequests"> | null>(null);
+
+	// Derive the open request from the live query so it stays reactive and
+	// falls back to null once the row leaves the list (e.g. after delete).
+	const detailRequest = useMemo(
+		() => requests?.find(r => r._id === detailId) ?? null,
+		[requests, detailId],
+	);
 
 	const volunteerOptions = useMemo(
 		() => (volunteers ?? []).map(v => ({
@@ -58,6 +67,7 @@ export function AdminDashboard() {
 
 	return (
 		<div className="flex flex-col gap-8">
+			<AdminRequestDetail request={detailRequest} onClose={() => setDetailId(null)} />
 			<div>
 				<Heading level={1} size={8}>Admin dashboard</Heading>
 				<Text size={2} color="gray" className="mt-1">
@@ -82,13 +92,23 @@ export function AdminDashboard() {
 											{r.owner?.name ?? r.owner?.email ?? "Unknown requester"}
 										</Text>
 									</div>
-									<Badge
-										variant="soft"
-										size={1}
-										color={statusBadgeColor(r.status as HelpRequestStatus)}
-									>
-										{HELP_REQUEST_STATUS_LABEL[r.status as HelpRequestStatus]}
-									</Badge>
+									<div className="flex items-center gap-2">
+										<Badge
+											variant="soft"
+											size={1}
+											color={statusBadgeColor(r.status as HelpRequestStatus)}
+										>
+											{HELP_REQUEST_STATUS_LABEL[r.status as HelpRequestStatus]}
+										</Badge>
+										<Button
+											variant="soft"
+											color="gray"
+											size={1}
+											onPress={() => setDetailId(r._id)}
+										>
+											View / edit
+										</Button>
+									</div>
 								</div>
 								<div className="mt-3 flex flex-wrap gap-2">
 									<select

--- a/apps/lomoweb/app/app/admin/admin-request-detail.tsx
+++ b/apps/lomoweb/app/app/admin/admin-request-detail.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import type { FunctionReturnType } from "convex/server";
+import type { HelpRequestStatus } from "@/lib/help-request-status";
+import { api } from "@repo/convex-backend/convex/_generated/api";
+import { Badge } from "@repo/ui/badge";
+import { Button } from "@repo/ui/button";
+import { Group, Label } from "@repo/ui/field";
+import { Heading } from "@repo/ui/heading";
+import { Modal, ModalOverlay } from "@repo/ui/modal";
+import { Text } from "@repo/ui/text";
+import { Input, TextArea, TextField } from "@repo/ui/text-field";
+import { useMutation } from "convex/react";
+import { useEffect, useState } from "react";
+import {
+	HELP_REQUEST_CATEGORY_IDS,
+	helpRequestCategoryLabel,
+} from "@/lib/help-request-category";
+import { HELP_REQUEST_STATUS_LABEL, statusBadgeColor } from "@/lib/help-request-status";
+
+type AdminRequest = FunctionReturnType<typeof api.helpRequests.listAllForAdmin>[number];
+
+export function AdminRequestDetail({
+	request,
+	onClose,
+}: {
+	request: AdminRequest | null;
+	onClose: () => void;
+}) {
+	const updateRequest = useMutation(api.helpRequests.adminUpdateRequest);
+	const deleteRequest = useMutation(api.helpRequests.adminDeleteRequest);
+
+	const [title, setTitle] = useState("");
+	const [summary, setSummary] = useState("");
+	const [details, setDetails] = useState("");
+	const [category, setCategory] = useState("");
+	const [saving, setSaving] = useState(false);
+	const [deleting, setDeleting] = useState(false);
+	const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+	// Reset the form whenever a different request is opened.
+	useEffect(() => {
+		setTitle(request?.title ?? "");
+		setSummary(request?.summary ?? "");
+		setDetails(request?.details ?? "");
+		setCategory(request?.category ?? "");
+		setConfirmingDelete(false);
+	}, [request]);
+
+	if (!request) {
+		return null;
+	}
+	const requestId = request._id;
+
+	async function handleSave() {
+		setSaving(true);
+		try {
+			await updateRequest({
+				requestId,
+				title,
+				summary,
+				details,
+				category: category as AdminRequest["category"],
+			});
+			onClose();
+		}
+		catch (e) {
+			console.error(e);
+			window.alert(e instanceof Error ? e.message : "Could not save changes.");
+		}
+		finally {
+			setSaving(false);
+		}
+	}
+
+	async function handleDelete() {
+		setDeleting(true);
+		try {
+			await deleteRequest({ requestId });
+			onClose();
+		}
+		catch (e) {
+			console.error(e);
+			window.alert(e instanceof Error ? e.message : "Could not delete request.");
+		}
+		finally {
+			setDeleting(false);
+		}
+	}
+
+	const busy = saving || deleting;
+
+	return (
+		<ModalOverlay isOpen isDismissable={!busy} onOpenChange={open => !open && onClose()}>
+			<Modal size={3} aria-label="Request details">
+				<div className="flex flex-col gap-5">
+					<div className="flex flex-wrap items-start justify-between gap-3">
+						<Heading level={2} size={6}>Request details</Heading>
+						<Badge
+							variant="soft"
+							size={1}
+							color={statusBadgeColor(request.status as HelpRequestStatus)}
+						>
+							{HELP_REQUEST_STATUS_LABEL[request.status as HelpRequestStatus]}
+						</Badge>
+					</div>
+
+					<div className="flex flex-col gap-1">
+						<DetailRow
+							label="Owner"
+							value={request.owner?.name ?? request.owner?.email ?? "Unknown requester"}
+						/>
+						{request.assignedHelperUserId && (
+							<DetailRow
+								label="Assigned helper"
+								value={request.assignedHelper?.name
+									?? request.assignedHelper?.email ?? "Unknown helper"}
+							/>
+						)}
+						{request.helperUserId && (
+							<DetailRow
+								label="Offering helper"
+								value={request.helper?.name ?? request.helper?.email ?? "Unknown helper"}
+							/>
+						)}
+					</div>
+
+					<div className="flex flex-col gap-4 border-t border-gray-5 pt-5">
+						<TextField value={title} onChange={setTitle} isDisabled={busy} className="w-full">
+							<Label>Title</Label>
+							<Group>
+								<Input />
+							</Group>
+						</TextField>
+
+						<label className="flex flex-col gap-1">
+							<Text size={2} weight="medium">Category</Text>
+							<select
+								className="min-h-10 rounded-md border border-gray-6 bg-gray-1 px-3"
+								value={category}
+								disabled={busy}
+								onChange={e => setCategory(e.target.value)}
+							>
+								{HELP_REQUEST_CATEGORY_IDS.map(id => (
+									<option key={id} value={id}>{helpRequestCategoryLabel(id)}</option>
+								))}
+							</select>
+						</label>
+
+						<TextField value={summary} onChange={setSummary} isDisabled={busy} className="w-full">
+							<Label>Summary</Label>
+							<Group>
+								<TextArea rows={2} />
+							</Group>
+						</TextField>
+
+						<TextField value={details} onChange={setDetails} isDisabled={busy} className="w-full">
+							<Label>Details</Label>
+							<Group>
+								<TextArea rows={5} />
+							</Group>
+						</TextField>
+					</div>
+
+					<div className="flex flex-wrap items-center justify-between gap-2 border-t border-gray-5 pt-5">
+						{confirmingDelete
+							? (
+									<div className="flex w-full flex-col gap-2">
+										<Text size={2} color="red">
+											Delete this request permanently? This cannot be undone —
+											its messages and notifications are removed too.
+										</Text>
+										<div className="flex flex-wrap gap-2">
+											<Button
+												variant="solid"
+												color="red"
+												isDisabled={busy}
+												onPress={handleDelete}
+											>
+												{deleting ? "Deleting…" : "Delete permanently"}
+											</Button>
+											<Button
+												variant="soft"
+												color="gray"
+												isDisabled={busy}
+												onPress={() => setConfirmingDelete(false)}
+											>
+												Cancel
+											</Button>
+										</div>
+									</div>
+								)
+							: (
+									<>
+										<Button
+											variant="soft"
+											color="red"
+											isDisabled={busy}
+											onPress={() => setConfirmingDelete(true)}
+										>
+											Delete
+										</Button>
+										<div className="flex flex-wrap gap-2">
+											<Button
+												variant="outline"
+												color="gray"
+												isDisabled={busy}
+												onPress={onClose}
+											>
+												Cancel
+											</Button>
+											<Button
+												variant="solid"
+												color="sage"
+												isDisabled={busy}
+												onPress={handleSave}
+											>
+												{saving ? "Saving…" : "Save changes"}
+											</Button>
+										</div>
+									</>
+								)}
+					</div>
+				</div>
+			</Modal>
+		</ModalOverlay>
+	);
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="flex items-center justify-between gap-3">
+			<Text size={2} color="gray">{label}</Text>
+			<Text size={2}>{value}</Text>
+		</div>
+	);
+}

--- a/apps/lomoweb/lib/help-request-category.ts
+++ b/apps/lomoweb/lib/help-request-category.ts
@@ -1,0 +1,15 @@
+import type { RequestCategoryId } from "./request-flow/types.ts";
+import { REQUEST_CATEGORIES } from "./request-flow/categories.ts";
+
+/** Category ids in the order they appear in the request flow. */
+export const HELP_REQUEST_CATEGORY_IDS: RequestCategoryId[]
+	= REQUEST_CATEGORIES.map(c => c.id);
+
+const CATEGORY_LABEL: Record<RequestCategoryId, string> = Object.fromEntries(
+	REQUEST_CATEGORIES.map(c => [c.id, c.title]),
+) as Record<RequestCategoryId, string>;
+
+/** Human-readable label for a category id (falls back to the raw id). */
+export function helpRequestCategoryLabel(category: string): string {
+	return CATEGORY_LABEL[category as RequestCategoryId] ?? category;
+}


### PR DESCRIPTION
# What Do

Expanding existing admin dashboard page.

# Images

## Before
The existing admin dashboard is gated by the admin setting on the user logged in and shows a list of ALL requests and gives the ability to assign volunteers.

<img width="816" height="1200" alt="image" src="https://github.com/user-attachments/assets/a8551824-d9e2-4182-9052-877e19b61b45" />

## This change!

### An edit/view button
<img width="854" height="1261" alt="image" src="https://github.com/user-attachments/assets/ab7b4243-905b-4d64-9c76-b11b2d5a3bb3" />

### Edit/view modal!
<img width="889" height="1117" alt="image" src="https://github.com/user-attachments/assets/5bda456a-2782-4eaa-8f12-0642f2b91428" />
