### PR TITLE
Design/improve desktop margins

### DIFF
--- a/apps/convex-backend/convex/_generated/api.d.ts
+++ b/apps/convex-backend/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as auth from "../auth.js";
 import type * as helpRequests from "../helpRequests.js";
 import type * as http from "../http.js";
+import type * as lib_currentUser from "../lib/currentUser.js";
 import type * as lib_siteEnv from "../lib/siteEnv.js";
 import type * as lib_verifyResendWebhook from "../lib/verifyResendWebhook.js";
 import type * as notifications from "../notifications.js";
@@ -29,6 +30,7 @@ declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   helpRequests: typeof helpRequests;
   http: typeof http;
+  "lib/currentUser": typeof lib_currentUser;
   "lib/siteEnv": typeof lib_siteEnv;
   "lib/verifyResendWebhook": typeof lib_verifyResendWebhook;
   notifications: typeof notifications;

--- a/apps/lomoweb/app/globals.css
+++ b/apps/lomoweb/app/globals.css
@@ -65,7 +65,7 @@
 /* Desktop app chrome: fixed width, height grows with content (see app/app/layout.tsx). */
 @media (min-width: 1024px) {
 	.lomo-desktop-app-frame {
-		--lomo-app-width: min(32rem, calc(100vw - 2rem));
+		--lomo-app-width: min(100rem, calc(100vw - 2rem));
 		width: var(--lomo-app-width);
 		max-width: var(--lomo-app-width);
 	}


### PR DESCRIPTION
# What Do
Widen page on desktop

# Screenshots
<img width="2790" height="1414" alt="image" src="https://github.com/user-attachments/assets/03feb91d-e007-4ea8-8f7d-9feca61e1454" />

## Still the right size for mobile
<img width="634" height="1358" alt="image" src="https://github.com/user-attachments/assets/570d8963-c9bd-4bdc-bef5-8cc56b9a37c2" />
